### PR TITLE
Typo: source/index.js not source/index.jsx

### DIFF
--- a/chapters/two.md
+++ b/chapters/two.md
@@ -10,7 +10,7 @@ source/
     |- Article/
       |- index.jsx
       |- styles.css
-  |- index.jsx
+  |- index.js
 
 ```
 


### PR DESCRIPTION
The supplied repo includes a source/index.js file and not .jsx. If a student creates an additional index.jsx alongside index.js, React/Webpack ignores the .jsx and only uses the .js